### PR TITLE
Generate new refdata and fix notebook

### DIFF
--- a/generate_reference.ipynb
+++ b/generate_reference.ipynb
@@ -73,13 +73,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "si_0_lvl = CMFGENEnergyLevelsParser('./cmfgen/energy_levels/SiI_OSC')\n",
-    "si_0_osc = CMFGENOscillatorStrengthsParser('./cmfgen/energy_levels/SiI_OSC')\n",
-    "si_1_lvl = CMFGENEnergyLevelsParser('./cmfgen/energy_levels/si2_osc_kurucz')\n",
-    "si_1_osc = CMFGENOscillatorStrengthsParser('./cmfgen/energy_levels/si2_osc_kurucz')\n",
+    "si_0_lvl = CMFGENEnergyLevelsParser('./cmfgen/energy_levels/SiI_OSC').base\n",
+    "si_0_osc = CMFGENOscillatorStrengthsParser('./cmfgen/energy_levels/SiI_OSC').base\n",
+    "si_1_lvl = CMFGENEnergyLevelsParser('./cmfgen/energy_levels/si2_osc_kurucz').base\n",
+    "si_1_osc = CMFGENOscillatorStrengthsParser('./cmfgen/energy_levels/si2_osc_kurucz').base\n",
     "\n",
-    "cmfgen_data = {'Si 0': {'levels': si_0_lvl, 'lines': si_0_osc},\n",
-    "               'Si 1': {'levels': si_1_lvl, 'lines': si_1_osc},}\n",
+    "cmfgen_data = {(16, 0): {'levels': si_0_lvl, 'lines': si_0_osc},\n",
+    "               (16, 1): {'levels': si_1_lvl, 'lines': si_1_osc},}\n",
     "\n",
     "cmfgen_reader = CMFGENReader(cmfgen_data, priority=20)"
    ]
@@ -106,11 +106,11 @@
    "source": [
     "atomic_weights = atom_data.atomic_weights.base.loc[1:14]  # H-Si  to do: make more consistent\n",
     "ionization_energies = atom_data.ionization_energies.base # to do: make more consistent\n",
-    "levels_all = atom_data._get_all_levels_data().drop(columns=[\"ds_id\"])\n",
-    "levels = atom_data.levels.drop(columns=[\"ds_id\"])\n",
+    "levels_all = atom_data._get_all_levels_data().drop(columns=[\"data_source_id\"])\n",
+    "levels = atom_data.levels.drop(columns=[\"data_source_id\"])\n",
     "levels_prepared = atom_data.levels_prepared\n",
-    "lines_all = atom_data._get_all_lines_data().drop(columns=[\"ds_id\"])\n",
-    "lines = atom_data.lines.drop(columns=[\"ds_id\"])\n",
+    "lines_all = atom_data._get_all_lines_data().drop(columns=[\"data_source_id\"])\n",
+    "lines = atom_data.lines.drop(columns=[\"data_source_id\"])\n",
     "lines_prepared = atom_data.lines_prepared\n",
     "macro_atom = atom_data.macro_atom\n",
     "macro_atom_prepared = atom_data.macro_atom_prepared\n",
@@ -143,6 +143,13 @@
     "refdata.put('collisions_prepared', collisions_prepared)\n",
     "refdata.put('zeta_data', zeta_data)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -161,7 +168,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.13"
+   "version": "3.6.15"
   }
  },
  "nbformat": 4,

--- a/test_data_ku_H-Si_ch_H-He_cm_Si_I-II.h5
+++ b/test_data_ku_H-Si_ch_H-He_cm_Si_I-II.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a5156e28d43f9f4481861aabb3696915e6559f79db6db5e4aa8eaea0fa53b196
-size 44591748
+oid sha256:9e8389626c5055fae5adf89131cccf031bc8506de98e238e3aeabbdda3dc80d2
+size 46815044


### PR DESCRIPTION
Refdata notebook was failing to generate new refdata - Fixed by updating the cmfgen data cell

Refdata updated to use `data_source_id` instead of `ds_id` for https://github.com/tardis-sn/carsus/pull/268