### PR TITLE
Edit generate_reference.ipynb according to changes made in carsus#251

### DIFF
--- a/generate_reference.ipynb
+++ b/generate_reference.ipynb
@@ -73,13 +73,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "si_0_lvl = CMFGENEnergyLevelsParser('./cmfgen/energy_levels/SiI_OSC')\n",
-    "si_0_osc = CMFGENOscillatorStrengthsParser('./cmfgen/energy_levels/SiI_OSC')\n",
-    "si_1_lvl = CMFGENEnergyLevelsParser('./cmfgen/energy_levels/si2_osc_kurucz')\n",
-    "si_1_osc = CMFGENOscillatorStrengthsParser('./cmfgen/energy_levels/si2_osc_kurucz')\n",
+    "si_0_lvl = CMFGENEnergyLevelsParser('./cmfgen/energy_levels/SiI_OSC').base\n",
+    "si_0_osc = CMFGENOscillatorStrengthsParser('./cmfgen/energy_levels/SiI_OSC').base\n",
+    "si_1_lvl = CMFGENEnergyLevelsParser('./cmfgen/energy_levels/si2_osc_kurucz').base\n",
+    "si_1_osc = CMFGENOscillatorStrengthsParser('./cmfgen/energy_levels/si2_osc_kurucz').base\n",
     "\n",
-    "cmfgen_data = {'Si 0': {'levels': si_0_lvl, 'lines': si_0_osc},\n",
-    "               'Si 1': {'levels': si_1_lvl, 'lines': si_1_osc},}\n",
+    "cmfgen_data = {(14, 0): {'levels': si_0_lvl, 'lines': si_0_osc},\n",
+    "               (14, 1): {'levels': si_1_lvl, 'lines': si_1_osc},}\n",
     "\n",
     "cmfgen_reader = CMFGENReader(cmfgen_data, priority=20)"
    ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
The generate_reference notebook worked with the old `CMFGENReader` class, which was changed in carsus PR. This PR makes some small changes to the notebook so that it works with the new `CMFGENReader` class.

**Description**
<!--- Describe your changes in detail -->
Running the notebook used to return this error(and a few more): 
<details>
  <summary>Click</summary>
  
  ```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-6-cd47b10ea2e4> in <module>
      7                'Si 1': {'levels': si_1_lvl, 'lines': si_1_osc},}
      8 
----> 9 cmfgen_reader = CMFGENReader(cmfgen_data, priority=20)

~/workspace/code/tardis-main/carsus/carsus/io/cmfgen/base.py in __init__(self, data, priority)
    473         self.data=data
    474         self.ions = list(data.keys())
--> 475         self._get_levels_lines(data)
    476 
    477     @classmethod

~/workspace/code/tardis-main/carsus/carsus/io/cmfgen/base.py in _get_levels_lines(self, data)
    710             ion_charge = ion[1]
    711 
--> 712             symbol = convert_atomic_number2symbol(ion[0])
    713             logger.info(f'Loading atomic data for {symbol} {ion[1]}.')
    714 

~/workspace/code/tardis-main/carsus/carsus/util/helpers.py in convert_atomic_number2symbol(atomic_number)
     70 
     71 def convert_atomic_number2symbol(atomic_number):
---> 72     return ATOMIC_NUMBER2SYMBOL[atomic_number]
     73 
     74 

KeyError: 'S'

  ```
</details>

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [ ] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [X] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [X] I have assigned and requested two reviewers for this pull request.
