### PR TITLE
Add ionization_energies_prepared to reference data

### DIFF
--- a/generate_reference.ipynb
+++ b/generate_reference.ipynb
@@ -78,8 +78,8 @@
     "si_1_lvl = CMFGENEnergyLevelsParser('./cmfgen/energy_levels/si2_osc_kurucz')\n",
     "si_1_osc = CMFGENOscillatorStrengthsParser('./cmfgen/energy_levels/si2_osc_kurucz')\n",
     "\n",
-    "cmfgen_data = {'Si 0': {'levels': si_0_lvl, 'lines': si_0_osc},\n",
-    "               'Si 1': {'levels': si_1_lvl, 'lines': si_1_osc},}\n",
+    "cmfgen_data = {(14,0): {'levels': si_0_lvl.base, 'lines': si_0_osc.base},\n",
+    "               (14,1): {'levels': si_1_lvl.base, 'lines': si_1_osc.base},}\n",
     "\n",
     "cmfgen_reader = CMFGENReader(cmfgen_data, priority=20)"
    ]
@@ -104,8 +104,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "atomic_weights = atom_data.atomic_weights.base.loc[1:14]  # H-Si  to do: make more consistent\n",
-    "ionization_energies = atom_data.ionization_energies.base # to do: make more consistent\n",
+    "atomic_weights = atom_data.atomic_weights.base.loc[1:14]  # H-Si  to do: store intermediate results\n",
+    "ionization_energies = atom_data.ionization_energies.base\n",
+    "ionization_energies_prepared = atom_data.ionization_energies_prepared\n",
     "levels_all = atom_data._get_all_levels_data().drop(columns=[\"ds_id\"])\n",
     "levels = atom_data.levels.drop(columns=[\"ds_id\"])\n",
     "levels_prepared = atom_data.levels_prepared\n",
@@ -118,7 +119,7 @@
     "macro_atom_references_prepared = atom_data.macro_atom_references_prepared\n",
     "collisions = atom_data.collisions.drop(columns=[\"btemp\", \"bscups\"])\n",
     "collisions_prepared = atom_data.collisions_prepared\n",
-    "zeta_data = atom_data.zeta_data.base  # to do: make more consistent"
+    "zeta_data = atom_data.zeta_data.base  # to do: store intermediate results"
    ]
   },
   {
@@ -129,6 +130,7 @@
    "source": [
     "refdata.put('atomic_weights', atomic_weights)\n",
     "refdata.put('ionization_energies', ionization_energies)\n",
+    "refdata.put('ionization_energies_prepared', ionization_energies_prepared)\n",
     "refdata.put('levels_all', levels_all)\n",
     "refdata.put('levels', levels)\n",
     "refdata.put('levels_prepared', levels_prepared)\n",
@@ -142,6 +144,15 @@
     "refdata.put('collisions', collisions)\n",
     "refdata.put('collisions_prepared', collisions_prepared)\n",
     "refdata.put('zeta_data', zeta_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "refdata.close()"
    ]
   }
  ],
@@ -161,7 +172,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.13"
+   "version": "3.6.15"
   }
  },
  "nbformat": 4,

--- a/test_data_ku_H-Si_ch_H-He_cm_Si_I-II.h5
+++ b/test_data_ku_H-Si_ch_H-He_cm_Si_I-II.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a5156e28d43f9f4481861aabb3696915e6559f79db6db5e4aa8eaea0fa53b196
-size 44591748
+oid sha256:3748e7decf9be8fe1e4295ba22be30db062ea985eab43728e9d156c7f2ebcbef
+size 62177460


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
After https://github.com/tardis-sn/carsus/pull/251 we difference `ionization_energies` from `ionization_energies_prepared` dataframes, and we should store both in the reference data to compare them appropriately.

See also https://github.com/tardis-sn/carsus/pull/276

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

Locally.

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [x] I have assigned and requested two reviewers for this pull request.
