### PR TITLE
Add reference files for testing Chianti submodule using Pytest Arraydiff

### DIFF
--- a/arraydiff/test_chianti_bound_levels_n_5.h5
+++ b/arraydiff/test_chianti_bound_levels_n_5.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd46e5ad3b64253e8b9f162cf684b856384e8c5edde4020eb0c8409801b7b40c
+size 1073600

--- a/arraydiff/test_chianti_bound_levels_ne_2.h5
+++ b/arraydiff/test_chianti_bound_levels_ne_2.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf7206d1b9550074540e1ff413c9cf184eb93f900addd971e737976777d182a9
+size 1081080

--- a/arraydiff/test_chianti_bound_lines_n_5.h5
+++ b/arraydiff/test_chianti_bound_lines_n_5.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e31beb50b3a3b135c3ffae7ace02b240a2e866053ad6c168375cdd4f40271786
+size 1080816

--- a/arraydiff/test_chianti_bound_lines_ne_2.h5
+++ b/arraydiff/test_chianti_bound_lines_ne_2.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb3e9ad1262889b89df1c18e1aa319481dad7f3ec29d0593bb16afc2888d9bd8
+size 1127509

--- a/arraydiff/test_chianti_reader_read_collisions_n_5.h5
+++ b/arraydiff/test_chianti_reader_read_collisions_n_5.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef156b914c3f127b31855742d2ae3d75f5fad1e50b7ff120e41b613515927f32
+size 1320016

--- a/arraydiff/test_chianti_reader_read_collisions_ne_2.h5
+++ b/arraydiff/test_chianti_reader_read_collisions_ne_2.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9bf4fad3cd976e5c088ad24a5adb90fec3f4be595f829b2c0b6d30ed3c57d3b5
+size 6475604

--- a/arraydiff/test_chianti_reader_read_levels_n_5.h5
+++ b/arraydiff/test_chianti_reader_read_levels_n_5.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b8eb8bf3046fcf647ae43c2611de91a56be00b1ad7fac89c08ae10e7ccd72d7
+size 1152120

--- a/arraydiff/test_chianti_reader_read_levels_ne_2.h5
+++ b/arraydiff/test_chianti_reader_read_levels_ne_2.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09db0be32705c221c42c64a436e16dee321c4a7d18f0596e6118f2aa7ba94f99
+size 1081080

--- a/arraydiff/test_chianti_reader_read_lines_n_5.h5
+++ b/arraydiff/test_chianti_reader_read_lines_n_5.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9dd60cc97188fe9cf818dfdd5256d49adf86e3df80089882a6ab25ea72a420b6
+size 1890920

--- a/arraydiff/test_chianti_reader_read_lines_ne_2.h5
+++ b/arraydiff/test_chianti_reader_read_lines_ne_2.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6fe1d09b910bc6fd6057a12d5615e02163f5be62a3df3cd245dd9b1ac45f22f7
+size 1127509

--- a/arraydiff/test_cols_H-He.h5
+++ b/arraydiff/test_cols_H-He.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3369db0c49382884018c87d2f2c8b0502b6f8780ecc13d3113607b92e629269e
+size 1129896

--- a/arraydiff/test_cols_N.h5
+++ b/arraydiff/test_cols_N.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a9581b9d7ad675b358236af7f983d755621f3dbbfcbf2d988cdb4269cfe3372
+size 8546284

--- a/arraydiff/test_levels_H-He.h5
+++ b/arraydiff/test_levels_H-He.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0dcd8bf51869dc0c91c242c9523307d789dbccfc6f4e2edfeffc1785a6be0cae
+size 1069712

--- a/arraydiff/test_levels_N.h5
+++ b/arraydiff/test_levels_N.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59387b0aba4d25e98d6c6dcfba64053ce72877c6c50a780663ca9a20fdd84789
+size 1123802

--- a/arraydiff/test_lines_H-He.h5
+++ b/arraydiff/test_lines_H-He.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:183a25b01f99714e45729ff5d93d6ebfec2ef376f076f2942d6dea8f7cc94898
+size 1072304

--- a/arraydiff/test_lines_N.h5
+++ b/arraydiff/test_lines_N.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf16296edcd76a95cd2e3354d383a054990b7ae49dea89f2b1f6f131bc266d92
+size 1868408


### PR DESCRIPTION
### :pencil: Description

**Type:** :vertical_traffic_light: `testing` 

<!-- Write a complete description of your changes, including the necessary context or any piece of information required to understand your work.

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 
-->
This PR contains reference files used(and generated) by Pytest Arraydiff to test the Chianti submodule.

### :pushpin: Resources

Examples, notebooks, and links to useful references.
Please see PR https://github.com/tardis-sn/carsus/pull/312

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
