### PR TITLE
Add NNDC decay data to refdata

### DIFF
--- a/generate_reference.ipynb
+++ b/generate_reference.ipynb
@@ -30,6 +30,7 @@
     "from carsus.io.zeta import KnoxLongZeta\n",
     "from carsus.io.chianti_ import ChiantiReader\n",
     "from carsus.io.cmfgen import CMFGENEnergyLevelsParser, CMFGENOscillatorStrengthsParser, CMFGENReader\n",
+    "from carsus.io.nuclear import NNDCReader\n",
     "from carsus.io.output import TARDISAtomData"
    ]
   },
@@ -64,7 +65,8 @@
     "ionization_energies = NISTIonizationEnergies(GFALL_IONS)\n",
     "gfall_reader = GFALLReader(ions=GFALL_IONS)\n",
     "chianti_reader = ChiantiReader(ions=CHIANTI_IONS, collisions=True, priority=20)\n",
-    "zeta_data = KnoxLongZeta()"
+    "zeta_data = KnoxLongZeta()\n",
+    "nndc_reader = NNDCReader()"
    ]
   },
   {
@@ -95,7 +97,8 @@
     "                           gfall_reader,\n",
     "                           zeta_data,\n",
     "                           chianti_reader,\n",
-    "                           cmfgen_reader)"
+    "                           cmfgen_reader,\n",
+    "                           nndc_reader)"
    ]
   },
   {
@@ -119,7 +122,8 @@
     "macro_atom_references_prepared = atom_data.macro_atom_references_prepared\n",
     "collisions = atom_data.collisions.drop(columns=[\"btemp\", \"bscups\"])\n",
     "collisions_prepared = atom_data.collisions_prepared\n",
-    "zeta_data = atom_data.zeta_data.base  # to do: store intermediate results"
+    "zeta_data = atom_data.zeta_data.base  # to do: store intermediate results\n",
+    "decay_data = atom_data.nndc_reader.decay_data"
    ]
   },
   {
@@ -143,7 +147,8 @@
     "refdata.put('macro_atom_references_prepared', macro_atom_references_prepared)\n",
     "refdata.put('collisions', collisions)\n",
     "refdata.put('collisions_prepared', collisions_prepared)\n",
-    "refdata.put('zeta_data', zeta_data)"
+    "refdata.put('zeta_data', zeta_data)\n",
+    "refdata.put('nndc_decay_data', decay_data)"
    ]
   },
   {

--- a/test_data_ku_H-Si_ch_H-He_cm_Si_I-II.h5
+++ b/test_data_ku_H-Si_ch_H-He_cm_Si_I-II.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3748e7decf9be8fe1e4295ba22be30db062ea985eab43728e9d156c7f2ebcbef
-size 62177460
+oid sha256:139538b0fae936557a7a7e36db37894fed6add43285533b5f22873eeb68b5d5c
+size 97310712


### PR DESCRIPTION
### :pencil: Description

Adds the NNDC Decay data to the test-refdata and modifies the generate_reference.ipynb to create the above test data.


The refdata created would help testing the changes in [#350](https://github.com/tardis-sn/carsus/pull/350).

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (describe)
Ran the notebook and verified the existence of the decay dataframe.
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
